### PR TITLE
Removes the use of unsafeRefEq.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,7 +12,6 @@
     "purescript-effect": "^2.0.0",
     "purescript-filterable": "^3.0.0",
     "purescript-nullable": "^4.0.0",
-    "purescript-unsafe-reference": "purescript-contrib/purescript-unsafe-reference#^3.0.1",
     "purescript-js-timers": "^4.0.1",
     "purescript-now": "^4.0.0"
   },


### PR DESCRIPTION
Hello,

This removes the use of `unsafeRefEq`.

In its place, it generates a unique integer per subscriber which is used to delete the subscriber when the cancellation function is called. Note that the integer may not be unique if two subscribers subscribe at the same time and/or if the integer overflows but that would be a considerable amount of subscribers. Another solution would be [purescript-uuid](https://github.com/spicydonuts/purescript-uuid) at the cost of additional time, space, dependencies, and FFI.

This will help out the [PureScript Native C++ back end](https://github.com/andyarvanitis/purescript-native/tree/cpp) and possibility others. 

:+1: 