### PR TITLE
Update library for PureScript 0.14

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,21 +7,21 @@
     "output"
   ],
   "dependencies": {
-    "purescript-prelude": "^4.0.1",
-    "purescript-console": "^4.1.0",
-    "purescript-effect": "^2.0.0",
-    "purescript-filterable": "^3.0.0",
-    "purescript-nullable": "^4.0.0",
-    "purescript-unsafe-reference": "purescript-contrib/purescript-unsafe-reference#^3.0.1",
-    "purescript-js-timers": "^4.0.1",
-    "purescript-now": "^4.0.0"
+    "purescript-prelude": "master",
+    "purescript-console": "master",
+    "purescript-effect": "master",
+    "purescript-filterable": "thomashoneyman/purescript-filterable#master",
+    "purescript-nullable": "main",
+    "purescript-unsafe-reference": "main",
+    "purescript-js-timers": "main",
+    "purescript-now": "main"
   },
   "devDependencies": {
-    "purescript-psci-support": "^4.0.0"
+    "purescript-psci-support": "master"
   },
   "license": "BSD-3-Clause",
   "repository": {
     "type": "git",
-    "url": "git://github.com/paf31/purescript-event.git"
+    "url": "https://github.com/paf31/purescript-event.git"
   }
 }

--- a/src/FRP/Event.purs
+++ b/src/FRP/Event.purs
@@ -12,7 +12,7 @@ import Prelude
 import Control.Alternative (class Alt, class Alternative, class Plus)
 import Control.Apply (lift2)
 import Data.Array (deleteBy)
-import Data.Either (either, fromLeft, fromRight, hush, isLeft, isRight)
+import Data.Either (either, hush, isLeft, isRight)
 import Data.Compactable (class Compactable)
 import Data.Filterable (class Filterable, filterMap)
 import Data.Foldable (sequence_, traverse_)
@@ -23,7 +23,7 @@ import Effect.Unsafe (unsafePerformEffect)
 import FRP.Event.Class (class Filterable, class IsEvent, count, filterMap, fix,
                         fold, folded, gate, gateBy, keepLatest, mapAccum,
                         sampleOn, sampleOn_, withLast) as Class
-import Partial.Unsafe (unsafePartial)
+import Partial.Unsafe (unsafePartial, unsafeCrashWith)
 import Unsafe.Reference (unsafeRefEq)
 
 -- | An `Event` represents a collection of discrete occurrences with associated
@@ -45,8 +45,8 @@ instance functorEvent :: Functor Event where
 instance compactableEvent :: Compactable Event where
   compact xs = map (\x -> unsafePartial fromJust x) (filter isJust xs)
   separate xs =
-    { left: unsafePartial (map fromLeft) (filter isLeft xs)
-    , right: unsafePartial (map fromRight) (filter isRight xs)
+    { left: map (either identity (\_ -> unsafeCrashWith "Expected Left")) (filter isLeft xs)
+    , right: map (either (\_ -> unsafeCrashWith "Expected Right") identity) (filter isRight xs)
     }
 
 instance filterableEvent :: Filterable Event where


### PR DESCRIPTION
👋 Hi Phil!

This PR updates `event` for compatibility with PureScript 0.14. I've opened this pull request instead of waiting for the official release because Halogen depends on this library, and I think users would really appreciate being able to use Halogen right off the bat when PureScript 0.14 is released. With this library ready to go we can ensure that Halogen is in the initial package set.

Specifically, this PR does two things:

First, I've updated library dependencies to the relevant master branches (other than `filterable`, which is awaiting https://github.com/LiamGoodacre/purescript-filterable/pull/20).

Second, I've replaced `Data.Either.fromLeft` and `Data.Either.fromRight` with manual implementations (`either identity (\_ -> unsafeCrashWith "Expected Left")`, for example) because these functions are now total upstream. For context, please see:

* https://github.com/purescript/purescript-either/issues/56
* https://github.com/purescript/purescript-either/issues/47

I also took the extra step of updating the repository URL in the Bower file so that it matches the [PureScript registry](https://github.com/purescript/registry). The URL in your local Bower file must match the URL in the registry in order for you to publish new versions of the library to Pursuit.

---

When PureScript 0.14 is released, then you'll still have to make a new release of this library; luckily, if this PR is already merged then you'll only need to take these steps:

1. Update your Bower file to point to the new major versions of your dependencies, instead of `master`
2. Commit and tag a new major version of this library
3. (Optionally) publish the new documentation to Pursuit with `pulp publish`

I can circle back when we've released new versions of your dependencies. Once you've made a release of your own, then I can update the relevant downstream libraries and make sure that `event` is up to date in the package set. Please let me know if I can be helpful with any other step!